### PR TITLE
use the attribute specified in the 1.3.0 ssh-hardening cookbook release

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,4 +15,4 @@ default['firewall']['firewalld']['permanent'] = true
 default['nginx']['default_site_enabled'] = false
 
 # when this is set to false, knife zero doesn't work!
-default['ssh-hardening']['ssh']['server']['allow_tcp_forwarding'] = true
+default['ssh']['allow_tcp_forwarding']    = false   # sshd


### PR DESCRIPTION
the master branch of the ssh-hardening cookbook is too far ahead of the release tag